### PR TITLE
FEAT: HTTP functionality in comment view

### DIFF
--- a/rare/urls.py
+++ b/rare/urls.py
@@ -25,6 +25,8 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'posts', PostView, 'post')
 
 urlpatterns = [
+    path('register', register_user),
+    path('login', login_user),
     path('admin/', admin.site.urls),
     path('', include(router.urls))
 ]

--- a/rare/urls.py
+++ b/rare/urls.py
@@ -17,12 +17,14 @@ from django.conf.urls import include
 from django.contrib import admin
 from django.urls import path
 from rareapi.views.auth import login_user, register_user
+from rareapi.views.comments import CommentView
 from rareapi.views.posts import PostView
 from rest_framework import routers
 
 router = routers.DefaultRouter(trailing_slash=False)
 
 router.register(r'posts', PostView, 'post')
+router.register(r'comments', CommentView, 'comment')
 
 urlpatterns = [
     path('register', register_user),

--- a/rareapi/views/comments.py
+++ b/rareapi/views/comments.py
@@ -1,0 +1,76 @@
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from django.core.exceptions import ValidationError
+from django.contrib.auth.models import User
+
+
+from rareapi.models.comment import Comment
+from rareapi.models.rareUser import RareUser
+from rareapi.models.post import Post
+
+class CommentView(ViewSet):
+    def retrieve(self, request, pk):
+        try:
+            # player = request.query_params.get('player', None)
+            # if player is not None:
+            #     comments = comments.filter(player_id=player)
+            comment = Comment.objects.get(pk=pk)
+            serializer = CommentSerializer(comment)
+            return Response(serializer.data)
+        except comment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND) 
+    def list(self, request):
+        comments = Comment.objects.all()
+        post = request.query_params.get('post', None)
+        if post is not None:
+            comments = comments.filter(post_id=post)
+        serializer = CommentSerializer(comments, many=True)
+        return Response(serializer.data)
+    def create(self, request):
+        """Handle POST operations
+        Returns:
+            Response -- JSON serialized comment instance
+        """
+        author = RareUser.objects.get(user=request.auth.user)
+        post = Post.objects.get(pk = request.data['post'])
+        serializer = CreatecommentSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(author=author, post=post)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+    def update(self,request, pk):
+        """doc string"""
+        
+        comment = Comment.objects.get(pk=pk)
+        serializer = CreatecommentSerializer(comment, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+    def destroy(self, request, pk):
+        comment = Comment.objects.get(pk=pk)
+        comment.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('username',)
+class RareUserSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+    class Meta:
+        model = RareUser
+        fields = ('id', 'user')
+        depth =1
+class CommentSerializer(serializers.ModelSerializer):
+    """JSON serializer for game types
+    """
+    author = RareUserSerializer()
+    class Meta:
+        model = Comment
+        fields = ('id', "content", "post", "author", "created_on")
+        depth = 2
+
+class CreatecommentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ['id', "content", "post", "author"]


### PR DESCRIPTION
# Description
get, update, create, and delete methods in comment views

## Type of change
Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] in postman or thunderclient, got to : http://localhost:8000/comments, and perform GET, all comments should be displayed
- [ ] n postman or thunderclient, got to : http://localhost:8000/comments/1, and perform GET, just that comment should be displayed
- [ ] n postman or thunderclient, got to : http://localhost:8000/comments, and perform POST, using the following object:
{
    "content": "test comment",
    "author": 1,
    "post": 1
}, perform GET with same address and that comment should appear in list
- [ ] created_on property in database should be todays data
- [ ]  n postman or thunderclient, got to : http://localhost:8000/comments/${<comment_id>}, and perform POST, using the following object:
{
 
    "content": "test comment edit",
    "author": 1,
    "post": 1
},
- [ ] [in](http://localhost:8000/comments/${<comment_id>}, and perform delete

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

TEST OBJECT:
{
    "content": "test comment",
    "author": 1,
    "post": 1
}